### PR TITLE
Bug/local broker context

### DIFF
--- a/fail/fail.go
+++ b/fail/fail.go
@@ -58,6 +58,12 @@ func Status(err error) int {
 		return errCode.Code()
 	}
 
+	// This is how AWS reports HTTP style errors, so make this convenient.
+	var errHTTPStatusCode errorWithHTTPStatusCode
+	if errors.As(err, &errHTTPStatusCode) {
+		return errHTTPStatusCode.HTTPStatusCode()
+	}
+
 	return http.StatusInternalServerError
 }
 
@@ -280,6 +286,11 @@ type errorWithStatusCode interface {
 type errorWithCode interface {
 	error
 	Code() int
+}
+
+type errorWithHTTPStatusCode interface {
+	error
+	HTTPStatusCode() int
 }
 
 // ErrorHandler is the generic function signature for something that accepts errors

--- a/fail/fail_test.go
+++ b/fail/fail_test.go
@@ -50,6 +50,22 @@ func (suite *FailSuite) TestStatus() {
 	suite.Equal(500, fail.Status(errWithStatusCode{statusCode: 500}))
 	suite.Equal(503, fail.Status(errWithStatusCode{statusCode: 503}))
 	suite.Equal(404, fail.Status(errWithStatusCode{statusCode: 404}))
+	suite.Equal(500, fail.Status(errorWithHTTPStatusCode{httpStatusCode: 500}))
+	suite.Equal(503, fail.Status(errorWithHTTPStatusCode{httpStatusCode: 503}))
+	suite.Equal(404, fail.Status(errorWithHTTPStatusCode{httpStatusCode: 404}))
+
+	// Wrapping w/ %w verb should still allow status retrieval.
+	suite.Equal(401, fail.Status(fmt.Errorf("wrapped failure: %w", errWithCode{code: 401})))
+	suite.Equal(401, fail.Status(fmt.Errorf("wrapped failure: %w", errWithStatusCode{statusCode: 401})))
+	suite.Equal(401, fail.Status(fmt.Errorf("wrapped failure: %w", errorWithHTTPStatusCode{httpStatusCode: 401})))
+
+	var wrapped error
+	wrapped = errWithCode{code: 401}
+	wrapped = fmt.Errorf("wrapped failure 1: %w", wrapped)
+	wrapped = fmt.Errorf("wrapped failure 2: %w", wrapped)
+	wrapped = fmt.Errorf("wrapped failure 3: %w", wrapped)
+	wrapped = fmt.Errorf("wrapped failure 4: %w", wrapped)
+	suite.Equal(401, fail.Status(wrapped))
 }
 
 func (suite *FailSuite) TestUnexpected() {
@@ -410,5 +426,17 @@ func (err errWithStatusCode) StatusCode() int {
 }
 
 func (err errWithStatusCode) Error() string {
+	return ""
+}
+
+type errorWithHTTPStatusCode struct {
+	httpStatusCode int
+}
+
+func (err errorWithHTTPStatusCode) HTTPStatusCode() int {
+	return err.httpStatusCode
+}
+
+func (err errorWithHTTPStatusCode) Error() string {
 	return ""
 }


### PR DESCRIPTION
When using a `local.Broker` for the event-based gateway, the context of the publishing code was being used as the input context for async subscribers. This meant that when the original context was cancelled due to the HTTP call being over, the subscribers would be using already-completed context.

Now, the local broker creates a new context for the subscriber handlers. Context metadata is still propagated exactly the same since that binding occurs afterwards, anyway.