### PR TITLE
Fixed many lifecycle bugs w/ the websocket registry.

### DIFF
--- a/services/gateways/apis/gateway.go
+++ b/services/gateways/apis/gateway.go
@@ -15,7 +15,6 @@ import (
 	"github.com/bridgekitio/frodo/fail"
 	"github.com/bridgekitio/frodo/internal/naming"
 	"github.com/bridgekitio/frodo/internal/quiet"
-	"github.com/bridgekitio/frodo/internal/radix"
 	"github.com/bridgekitio/frodo/services"
 	"github.com/rs/cors"
 )
@@ -26,7 +25,6 @@ import (
 func NewGateway(address string, options ...GatewayOption) *Gateway {
 	router := http.NewServeMux()
 	codecs := codec.New()
-	websockets := radix.New[*Websocket]()
 	gw := Gateway{
 		router:          router,
 		codecs:          codecs,
@@ -35,7 +33,7 @@ func NewGateway(address string, options ...GatewayOption) *Gateway {
 		server:          &http.Server{Addr: address, Handler: router},
 		tlsCert:         "",
 		tlsKey:          "",
-		websockets:      &websockets,
+		websockets:      newWebsocketRegistry(),
 		notFoundHandler: defaultNotFoundHandler(codecs),
 	}
 	for _, option := range options {
@@ -58,7 +56,7 @@ type Gateway struct {
 	tlsCert         string
 	tlsKey          string
 	notFoundHandler http.HandlerFunc
-	websockets      *radix.Tree[*Websocket]
+	websockets      *websocketRegistry
 	cors            *cors.Cors
 }
 


### PR DESCRIPTION
Dealt with a number of issues related to the underlying registry of all open websockets:

* `Websocket.close()` now sets the connection to nil so it can report that it's no longer active.
* The read loop in `startListening()` now closes the whole socket, not just the connection, so lifecycle cleanup can actually happen.
* The websocket registry now contains a mutex to make sure we're not adding/removing while trying to walk prefixes.
* The `WalkWebsockets()` callback no longer takes the socket id as a parameter... you already have the entire `Websocket` as a parameter, so you can get the id that way... it was redundant.
* All connections automatically `startListening()` - this ensures that all sockets have automatic lifecycle handling.