### PR TITLE
Properly sets Sec-WebSocket-Protocol header on upgraded websockets

### DIFF
--- a/generate/templates/client.js.tmpl
+++ b/generate/templates/client.js.tmpl
@@ -69,7 +69,7 @@ class {{ .Service.Name }}Client {
         const authToken = (authorization || this._authorization || "").trim();
 
         {{- if $apiRoute.RouteType.Websocket }}
-        return new WebSocket(this._baseSocketURL + '/' + requestPath, authToken ? [`Authorization-Bearer-${authToken}`] : []);
+        return new WebSocket(this._baseSocketURL + '/' + requestPath, authToken ? [`Authorization.Bearer.${authToken}`] : []);
         {{- else }}
         const fetchOptions = {
             method: method,

--- a/services/gateways/apis/middleware.go
+++ b/services/gateways/apis/middleware.go
@@ -97,33 +97,33 @@ func restoreAuthorization() HTTPMiddlewareFunc {
 	}
 	readWebsocketAuth := func(req *http.Request) string {
 		// This header's values only allow single tokens, so we can't do something nice like one of the values
-		// as "Authorization: Bearer foo". Instead, we need to do "Authorization-Bearer-foo" to make browsers happy, so this
+		// as "Authorization: Bearer foo". Instead, we need to do "Authorization.Bearer.foo" to make browsers happy, so this
 		// logic tries to pick apart that formatted value to give the same format as the normal Authorization header.
 		for _, v := range req.Header[headerWebsocketProtocol] {
-			_, authValue, found := strings.Cut(v, "Authorization-") // Make sure this is one of our smuggled Authorization values.
+			_, authValue, found := strings.Cut(v, "Authorization.") // Make sure this is one of our smuggled Authorization values.
 			if !found {
 				continue
 			}
 
-			// Split common schemes so "Bearer-123" becomes "Bearer 123" just as if you were using the normal Authorization header.
+			// Split common schemes so "Bearer.123" becomes "Bearer 123" just as if you were using the normal Authorization header.
 			switch {
-			case strings.HasPrefix(authValue, "Basic-"):
+			case strings.HasPrefix(authValue, "Basic."):
 				return "Basic " + authValue[6:]
-			case strings.HasPrefix(authValue, "Bearer-"):
+			case strings.HasPrefix(authValue, "Bearer."):
 				return "Bearer " + authValue[7:]
-			case strings.HasPrefix(authValue, "Digest-"):
+			case strings.HasPrefix(authValue, "Digest."):
 				return "Digest " + authValue[7:]
-			case strings.HasPrefix(authValue, "Token-"):
+			case strings.HasPrefix(authValue, "Token."):
 				return "Token " + authValue[6:]
-			case strings.HasPrefix(authValue, "HOBA-"):
+			case strings.HasPrefix(authValue, "HOBA."):
 				return "HOBA " + authValue[5:]
-			case strings.HasPrefix(authValue, "Mutual-"):
+			case strings.HasPrefix(authValue, "Mutual."):
 				return "Mutual " + authValue[7:]
-			case strings.HasPrefix(authValue, "VAPID-"):
+			case strings.HasPrefix(authValue, "VAPID."):
 				return "VAPID " + authValue[6:]
-			case strings.HasPrefix(authValue, "SCRAM-"):
+			case strings.HasPrefix(authValue, "SCRAM."):
 				return "SCRAM " + authValue[6:]
-			case strings.HasPrefix(authValue, "AWS4-HMAC-SHA256-"):
+			case strings.HasPrefix(authValue, "AWS4-HMAC-SHA256."):
 				return "AWS4-HMAC-SHA256 " + authValue[17:]
 			default:
 				return authValue

--- a/services/gateways/apis/websocket.go
+++ b/services/gateways/apis/websocket.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/bridgekitio/frodo/fail"
@@ -66,6 +67,12 @@ func ConnectWebsocket(ctx context.Context, connectionID string, opts WebsocketOp
 	w, ok := ctx.Value(responseContextKey{}).(http.ResponseWriter)
 	if !ok {
 		return nil, fail.Unexpected("error connecting websocket: missing response")
+	}
+
+	// What the hell are we doing here? In Javascript, you can't customize headers on the ws/wss request when trying to
+	// open a websocket. Unfortunately, that means we have to use "less pretty" ways to give users a way to do this.
+	ws.DefaultHTTPUpgrader.Protocol = func(value string) bool {
+		return strings.HasPrefix(value, "Authorization.")
 	}
 
 	// Upgrade the HTTP connection to a websocket.

--- a/services/server_test.go
+++ b/services/server_test.go
@@ -403,38 +403,44 @@ func (suite *ServerSuite) TestRestoreAuthorizationMiddleware() {
 		req.Header.Set(Authorization, "The beer has gone bad")
 	})
 
-	// Websocket auth needs to conform to the single-token format like "Authorization-SCHEME-VALUE" or "Authorization-VALUE", so this won't work
+	// Websocket auth needs to conform to the single-token format like "Authorization.SCHEME.VALUE" or "Authorization.VALUE", so this won't work
 	testCase("", func(req *http.Request) {
 		req.Header.Set(SecWebsocketProtocol, "Authorization: Bearer 12345")
+	})
+	testCase("", func(req *http.Request) {
+		req.Header.Set(SecWebsocketProtocol, "Authorization-Bearer-12345")
 	})
 
 	// Can fall back to using Sec-Websocket-Protocol when necessary (value only)
 	testCase("12345", func(req *http.Request) {
-		req.Header.Set(SecWebsocketProtocol, "Authorization-12345")
+		req.Header.Set(SecWebsocketProtocol, "Authorization.12345")
 	})
 
 	// Splits common schemes like "Basic-123" into the more canonical "Basic 123"
-	testCase("Basic ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization-Basic-ABC") })
-	testCase("Bearer ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization-Bearer-ABC") })
-	testCase("Digest ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization-Digest-ABC") })
-	testCase("Token ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization-Token-ABC") })
-	testCase("HOBA ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization-HOBA-ABC") })
-	testCase("Mutual ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization-Mutual-ABC") })
-	testCase("VAPID ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization-VAPID-ABC") })
-	testCase("SCRAM ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization-SCRAM-ABC") })
-	testCase("AWS4-HMAC-SHA256 ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization-AWS4-HMAC-SHA256-ABC") })
+	testCase("Basic ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization.Basic.ABC") })
+	testCase("Bearer ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization.Bearer.ABC") })
+	testCase("Digest ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization.Digest.ABC") })
+	testCase("Token ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization.Token.ABC") })
+	testCase("HOBA ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization.HOBA.ABC") })
+	testCase("Mutual ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization.Mutual.ABC") })
+	testCase("VAPID ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization.VAPID.ABC") })
+	testCase("SCRAM ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization.SCRAM.ABC") })
+	testCase("AWS4-HMAC-SHA256 ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization.AWS4-HMAC-SHA256.ABC") })
 
 	// Obscure/unknown schemes are left w/ the "-" splitting them. Sorry.
-	testCase("FooBar-ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization-FooBar-ABC") })
+	testCase("FooBar.ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization.FooBar.ABC") })
 
 	// Our scheme checks are CASE SENSITIVE... follow the standards, you scallywag, otherwise we're leaving the "-" in between them.
-	testCase("BaSIc-ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization-BaSIc-ABC") })
-	testCase("bearer-ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization-bearer-ABC") })
+	testCase("BaSIc.ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization.BaSIc.ABC") })
+	testCase("bearer.ABC", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization.bearer.ABC") })
+
+	// You should be allowed to have periods in your token value.
+	testCase("Bearer ABC.123..XYZ.", func(req *http.Request) { req.Header.Set(SecWebsocketProtocol, "Authorization.Bearer.ABC.123..XYZ.") })
 
 	// If you provide both, standard Authorization header wins.
 	testCase("Bearer 123", func(req *http.Request) {
 		req.Header.Set(Authorization, "Bearer 123")
-		req.Header.Set(SecWebsocketProtocol, "Authorization-Basic-456")
+		req.Header.Set(SecWebsocketProtocol, "Authorization.Basic.456")
 	})
 }
 


### PR DESCRIPTION
Since we smuggle websocket Authorization tokens using the `Sec-WebSocket-Protocol` header (since that's all we get access to in the browser), I didn't realize that you need to regurgitate that value on the upgrade response. Now, we do that so Chrome/Safari properly connect websockets that take both parameters.