### PR TITLE
Feature/redundancy hitlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ func main() {
         services.Listen(apis.NewGateway(":9000")),
         services.Register(calcService),
     )
-    server.Run()
+    server.Run(context.Background())
 }
 ```
 
@@ -422,7 +422,7 @@ func main() {
         services.Listen(events.NewGateway()), // <--- This is the only difference.
         services.Register(orderService),
     )
-    server.Run()
+    server.Run(context.Background())
 }
 ```
 
@@ -538,7 +538,7 @@ func main() {
         services.Listen(events.NewGateway(events.WithBroker(natsBroker))),
         services.Register(orderService),
     )
-    server.Run()
+    server.Run(context.Background())
 }
 ```
 
@@ -817,7 +817,7 @@ func main() {
         events.WithBroker(natsBroker),
         events.WithErrorListener(handleEventError),
     ))
-    server.Run()
+    server.Run(context.Background())
 }
 
 // handleEventError fires EVERY time ANY event-based method invocation fails.
@@ -856,7 +856,7 @@ func main() {
         services.Listen(events.NewGateway()),
         services.Register(calcService),
     )
-    server.Run()
+    server.Run(context.Background())
 }
 
 func LogRequest(ctx context.Context, req any, next services.HandlerFunc) (any, error) {
@@ -916,7 +916,7 @@ func main() {
         services.Listen(events.NewGateway()),
         services.Register(calcService),
     )
-    server.Run()
+    server.Run(context.Background())
 }
 ```
 
@@ -1197,7 +1197,7 @@ server := services.NewServer(
     services.Listen(events.NewGateway()),
     services.Register(userService, groupService, mailService, orderService),
 )
-server.Run()
+server.Run(ctx)
 ```
 
 ### To Run Them Is Micro/Mini Services
@@ -1210,7 +1210,7 @@ server := services.NewServer(
     services.Listen(events.NewGateway(events.WithBroker(natsBroker))),
     services.Register(userService),
 )
-server.Run()
+server.Run(ctx)
 
 // In groups/cmd/main.go
 groupService := groupGen.GroupServiceServer(groupHandler)
@@ -1219,7 +1219,7 @@ server := services.NewServer(
     services.Listen(events.NewGateway(events.WithBroker(natsBroker))),
     services.Register(groupService),
 )
-server.Run()
+server.Run(ctx)
 
 // And follow the pattern for the other 2 services...
 ```

--- a/eventsource/broker.go
+++ b/eventsource/broker.go
@@ -2,6 +2,7 @@ package eventsource
 
 import (
 	"context"
+	"io"
 	"strings"
 	"time"
 )
@@ -28,7 +29,7 @@ type Publisher interface {
 type Subscriber interface {
 	// Subscribe creates a one-off listener that will fire your handler function for
 	// EVERY instance of the event/key.
-	Subscribe(key string, handlerFunc EventHandlerFunc) (Subscription, error)
+	Subscribe(ctx context.Context, key string, handlerFunc EventHandlerFunc) (Subscription, error)
 
 	// SubscribeGroup creates a listener that is a member of a "Consumer Group". If there
 	// are other listeners in the same 'group', only one of them should have their
@@ -36,14 +37,14 @@ type Subscriber interface {
 	//
 	// This is akin to a "Consumer Group" if you are from the Kafka world or "Queue Group" if
 	// NATS is more of your jam.
-	SubscribeGroup(key string, group string, handlerFunc EventHandlerFunc) (Subscription, error)
+	SubscribeGroup(ctx context.Context, key string, group string, handlerFunc EventHandlerFunc) (Subscription, error)
 }
 
 // Subscription is simply a registration pointer that can allow you to stop listening at any time.
 type Subscription interface {
-	// Unsubscribe notifies the Broker/Subscriber that created this subscription that we
+	// Closer contains 'Close()' which notifies the Broker/Subscriber that created this subscription that we
 	// want to stop receiving events. Typically, this is done during process shutdown automatically.
-	Unsubscribe() error
+	io.Closer
 }
 
 // EventHandlerFunc is the signature for a function that can asynchronously handle an incoming event

--- a/eventsource/nats/nats.go
+++ b/eventsource/nats/nats.go
@@ -3,26 +3,32 @@ package nats
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/bridgekitio/frodo/eventsource"
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 )
 
-var ErrNotConnected = fmt.Errorf("not connected")
+var ErrNotConnected = fmt.Errorf("nats broker not connected")
 var ErrInvalidNamespace = fmt.Errorf("key does not have valid namespace: e.g. 'usercreated' instead of 'user.created'")
 
 // Broker creates a new event broker that distributes messages using NATS JetStream queues/groups.
 func Broker(options ...Option) eventsource.Broker {
 	c := client{
-		uri:               "nats://127.0.0.1:4222",
+		uri:               nats.DefaultURL,
 		mutex:             &sync.Mutex{},
-		streams:           map[string]*nats.StreamInfo{},
+		streams:           map[string]jetstream.Stream{},
 		retentionMaxAge:   7 * 24 * time.Hour,
 		retentionMaxMsgs:  -1,
 		retentionMaxBytes: -1,
+		inactiveThreshold: 1 * time.Hour,
+		onError: func(err error) {
+			log.Printf("[nats broker error] %v\n", err)
+		},
 	}
 	for _, option := range options {
 		option(&c)
@@ -32,7 +38,7 @@ func Broker(options ...Option) eventsource.Broker {
 		c.err = fmt.Errorf("nats connect error: %w", c.err)
 		return &c
 	}
-	if c.jetstream, c.err = c.conn.JetStream(); c.err != nil {
+	if c.js, c.err = jetstream.New(c.conn); c.err != nil {
 		c.err = fmt.Errorf("nats jetstream error: %w", c.err)
 		return &c
 	}
@@ -40,11 +46,12 @@ func Broker(options ...Option) eventsource.Broker {
 }
 
 type client struct {
-	uri   string
-	err   error
-	mutex *sync.Mutex
+	uri     string
+	err     error
+	mutex   *sync.Mutex
+	onError func(error)
 
-	streams       map[string]*nats.StreamInfo
+	streams       map[string]jetstream.Stream
 	subscriptions []subscription
 	username      string
 	password      string
@@ -52,142 +59,129 @@ type client struct {
 	retentionMaxAge   time.Duration
 	retentionMaxMsgs  int64
 	retentionMaxBytes int64
+	inactiveThreshold time.Duration
 
-	conn      *nats.Conn
-	jetstream nats.JetStreamContext
+	conn *nats.Conn
+	js   jetstream.JetStream
 }
 
 func (c *client) Publish(ctx context.Context, key string, payload []byte) error {
-	if err := c.loadStream(key); err != nil {
-		return fmt.Errorf("nats publish: %w", err)
+	if _, err := c.connectStream(ctx, key); err != nil {
+		return fmt.Errorf("broker publish error: %w", err)
 	}
-
-	if _, err := c.jetstream.Publish(key, payload, nats.Context(ctx)); err != nil {
-		return fmt.Errorf("nats publish: %w", err)
+	if _, err := c.js.Publish(ctx, key, payload); err != nil {
+		return fmt.Errorf("broker publish error: %w", err)
 	}
 	return nil
 }
 
-func (c *client) Subscribe(key string, handlerFunc eventsource.EventHandlerFunc) (eventsource.Subscription, error) {
-	if err := c.loadStream(key); err != nil {
-		return nil, fmt.Errorf("nats subscribe: %w", err)
-	}
-
-	sub, err := c.jetstream.Subscribe(key, c.toMsgHandler(handlerFunc))
-	if err != nil {
-		return nil, fmt.Errorf("nats subscribe: %w", err)
-	}
-	return subscription{sub: sub}, nil
+func (c *client) Subscribe(ctx context.Context, key string, handlerFunc eventsource.EventHandlerFunc) (eventsource.Subscription, error) {
+	return c.consume(ctx, key, "", handlerFunc)
 }
 
-func (c *client) SubscribeGroup(key string, group string, handlerFunc eventsource.EventHandlerFunc) (eventsource.Subscription, error) {
-	if err := c.loadStream(key); err != nil {
-		return nil, fmt.Errorf("nats subscribe group: %w", err)
+func (c *client) SubscribeGroup(ctx context.Context, key string, group string, handlerFunc eventsource.EventHandlerFunc) (eventsource.Subscription, error) {
+	return c.consume(ctx, key, group, handlerFunc)
+}
+
+func (c *client) consume(ctx context.Context, key string, group string, handlerFunc eventsource.EventHandlerFunc) (eventsource.Subscription, error) {
+	stream, err := c.connectStream(ctx, key)
+	if err != nil {
+		return nil, err
 	}
 
-	// NATS doesn't like periods in consumer group names, so convert them to underscores.
+	// NATS doesn't like periods in the names of things. Message key/subject is fine, but the names of streams/consumers is not cool.
 	group = strings.ReplaceAll(group, ".", "_")
 
-	sub, err := c.jetstream.QueueSubscribe(key, group, c.toMsgHandler(handlerFunc), nats.StartTime(time.Now()))
+	// The one-hour timeout doesn't delete messages older than an hour. It just auto-cleans up the metadata about a consumer, so
+	// if you create the same group 2 hours later, NATS will just treat it like this is the first time its ever seen this group.
+	// For now, we only support a DeliverLastPolicy, so it will start delivering after the most recent message anyway. We can
+	// revisit this if we want to support "catch-up" style broker behavior where instances will process all messages that
+	// came in while the consuming service was down. But... we don't do that yet, so this always-act-like-its-new approach
+	// is good enough for now.
+	consumer, err := stream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+		Durable:           group,
+		InactiveThreshold: c.inactiveThreshold,
+		DeliverPolicy:     jetstream.DeliverNewPolicy,
+		FilterSubject:     key,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("nats subscribe group: %w", err)
+		return nil, fmt.Errorf("broker consumer error: %w", err)
 	}
-	return subscription{sub: sub}, nil
+
+	consumerContext, err := consumer.Consume(c.toJetStreamMessageHandler(handlerFunc))
+	if err != nil {
+		return nil, fmt.Errorf("broker consumer context error: %w", err)
+	}
+	return subscription{consumer: consumer, consumerContext: consumerContext}, nil
 }
 
-func (c *client) toMsgHandler(handlerFunc eventsource.EventHandlerFunc) nats.MsgHandler {
-	return func(m *nats.Msg) {
+func (c *client) toJetStreamMessageHandler(handlerFunc eventsource.EventHandlerFunc) jetstream.MessageHandler {
+	return func(msg jetstream.Msg) {
+		if err := msg.Ack(); err != nil {
+			c.onError(fmt.Errorf("error during ack for '%s': %w", msg.Subject(), err))
+			return
+		}
+
 		err := handlerFunc(context.Background(), &eventsource.EventMessage{
 			Timestamp: time.Now(),
-			Key:       m.Subject,
-			Payload:   m.Data,
+			Key:       msg.Subject(),
+			Payload:   msg.Data(),
 		})
 		if err != nil {
-			fmt.Printf("[WARN] error handling subscription: %v: %v\n", m.Subject, err)
+			c.onError(fmt.Errorf("error handling event message '%s': %w", msg.Subject(), err))
 		}
 	}
 }
 
-func (c *client) loadStream(key string) error {
-	if c.err != nil {
-		return c.err
-	}
-	if c.jetstream == nil {
-		return ErrNotConnected
+// connectStream lazy creates the event stream where this key is supposed to go. Keys look like "FooService.BarMethod",
+// so this will create/update a stream named "FooService".
+func (c *client) connectStream(ctx context.Context, key string) (jetstream.Stream, error) {
+	if c.js == nil {
+		return nil, ErrNotConnected
 	}
 
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	// Keys are usually things like "FooService.SaveBar", so we want just
-	// the "FooService" bit as the service name.
-	namespace := eventsource.Namespace(key)
-	if namespace == "" {
-		return ErrInvalidNamespace
+	// Each service gets its own "stream" of events. No matter how methods you have, they'll all go into the same
+	// event stream for that service. The consumers (subscribers) will filter out just the methods they're interested in.
+	// The key we receive is the fully-qualified service method like "CalculatorService.Add". The stream name will be
+	// CalculatorService, so its Add, Subtract, Multiply, and other methods will all get published in there.
+	serviceName := eventsource.Namespace(key)
+	if serviceName == "" {
+		return nil, ErrInvalidNamespace
 	}
 
 	// You are probably going to call Publish/Subscribe(Group) a bunch of times for the same
-	// stream, so only round-trip all the way to NATS the first time. Also, if the info is
-	// in this map, we've already applied any changes to the
-	if _, ok := c.streams[namespace]; ok {
-		return nil
+	// stream, so only round-trip all the way to NATS the first time.
+	if stream, ok := c.streams[serviceName]; ok {
+		return stream, nil
 	}
 
-	switch info, err := c.jetstream.StreamInfo(namespace); err {
-	// The stream already exists in NATS. Now we need to see if you updated any desired
-	// settings on the stream such as the retention policy. If so, we need to push those
-	// changes to NATS before moving on.
-	case nil:
-		if info, err = c.updateStream(info); err != nil {
-			return fmt.Errorf("load stream: %w", err)
-		}
-		c.streams[namespace] = info
-		return nil
-
-	// We connected and NATS responded just fine. There's just no stream by this name,
-	// so let's make one. We will name the stream after the service (e.g. "UserService")
-	// and make sure that it accepts subjects matching any of the method
-	// names (e.g. "UserService.*").
-	case nats.ErrStreamNotFound:
-		info, err = c.jetstream.AddStream(&nats.StreamConfig{
-			Name:      namespace,
-			Subjects:  []string{namespace + ".*"},
-			Retention: nats.LimitsPolicy,
-			MaxAge:    c.retentionMaxAge,
-			MaxBytes:  c.retentionMaxBytes,
-			MaxMsgs:   c.retentionMaxMsgs,
-		})
-		c.streams[namespace] = info
-		return err
-
-	// Shit got fucky. You're going to have a bad time.
-	default:
-		return fmt.Errorf("load stream: %w", err)
-	}
-}
-
-func (c *client) updateStream(info *nats.StreamInfo) (*nats.StreamInfo, error) {
-	// Doesn't look like you've changed the configuration since you last started
-	// up the service. Just leave everything alone and move on.
-	if c.retentionMaxAge == info.Config.MaxAge &&
-		c.retentionMaxBytes == info.Config.MaxBytes &&
-		c.retentionMaxMsgs == info.Config.MaxMsgs {
-		return info, nil
+	stream, err := c.js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:      serviceName,
+		Subjects:  []string{serviceName + ".>"},
+		Retention: jetstream.LimitsPolicy,
+		MaxAge:    c.retentionMaxAge,
+		MaxBytes:  c.retentionMaxBytes,
+		MaxMsgs:   c.retentionMaxMsgs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("broker event stream error: %w", err)
 	}
 
-	config := info.Config
-	config.MaxAge = c.retentionMaxAge
-	config.MaxBytes = c.retentionMaxBytes
-	config.MaxMsgs = c.retentionMaxMsgs
-	return c.jetstream.UpdateStream(&config)
+	c.streams[serviceName] = stream
+	return stream, nil
 }
 
 type subscription struct {
-	sub *nats.Subscription
+	consumer        jetstream.Consumer
+	consumerContext jetstream.ConsumeContext
 }
 
-func (s subscription) Unsubscribe() error {
-	return s.sub.Unsubscribe()
+func (s subscription) Close() error {
+	s.consumerContext.Drain()
+	return nil
 }
 
 type Option func(c *client)
@@ -219,6 +213,12 @@ func WithMaxBytes(maxBytes int64) Option {
 func WithMaxMsgs(maxMsgs int64) Option {
 	return func(c *client) {
 		c.retentionMaxMsgs = maxMsgs
+	}
+}
+
+func WithInactiveThreshold(threshold time.Duration) Option {
+	return func(c *client) {
+		c.inactiveThreshold = threshold
 	}
 }
 

--- a/eventsource/nats/nats.go
+++ b/eventsource/nats/nats.go
@@ -88,7 +88,7 @@ func (c *client) SubscribeGroup(key string, group string, handlerFunc eventsourc
 	// NATS doesn't like periods in consumer group names, so convert them to underscores.
 	group = strings.ReplaceAll(group, ".", "_")
 
-	sub, err := c.jetstream.QueueSubscribe(key, group, c.toMsgHandler(handlerFunc))
+	sub, err := c.jetstream.QueueSubscribe(key, group, c.toMsgHandler(handlerFunc), nats.StartTime(time.Now()))
 	if err != nil {
 		return nil, fmt.Errorf("nats subscribe group: %w", err)
 	}

--- a/example/authorization/cmd/main.go
+++ b/example/authorization/cmd/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	// Fire up the API and shut down gracefully when we receive a SIGINT or SIGTERM signal.
 	go server.ShutdownOnInterrupt(10 * time.Second)
-	if err := server.Run(); err != nil {
+	if err := server.Run(context.Background()); err != nil {
 		panic(err)
 	}
 	fmt.Println("Bye bye...")

--- a/example/basic/cmd/main.go
+++ b/example/basic/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -25,7 +26,7 @@ func main() {
 
 	fmt.Println("Server running on http://localhost:8080")
 	go server.ShutdownOnInterrupt(2 * time.Second)
-	if err := server.Run(); err != nil {
+	if err := server.Run(context.Background()); err != nil {
 		panic(err)
 	}
 }

--- a/example/middleware/cmd/main.go
+++ b/example/middleware/cmd/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	// Fire up the API and shut down gracefully when we receive a SIGINT or SIGTERM signal.
 	go server.ShutdownOnInterrupt(10 * time.Second)
-	if err := server.Run(); err != nil {
+	if err := server.Run(context.Background()); err != nil {
 		panic(err)
 	}
 

--- a/example/multiservice/cmd/main.go
+++ b/example/multiservice/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -33,7 +34,7 @@ func main() {
 
 	// Fire up the API and shut down gracefully when we receive a SIGINT or SIGTERM signal.
 	go server.ShutdownOnInterrupt(10 * time.Second)
-	if err := server.Run(); err != nil {
+	if err := server.Run(context.Background()); err != nil {
 		panic(err)
 	}
 

--- a/generate/client_test.go
+++ b/generate/client_test.go
@@ -38,7 +38,7 @@ func (suite *GeneratedClientSuite) startServer() (string, func()) {
 		services.Listen(apis.NewGateway(address)),
 		services.Register(gen.SampleServiceServer(testext.SampleServiceHandler{Sequence: sequence})),
 	)
-	go func() { _ = server.Run() }()
+	go func() { _ = server.Run(context.Background()) }()
 
 	// Kinda crappy, but we need some time to make sure the server is up. Sometimes
 	// this goes so fast that the test case fires before the server is fully running.

--- a/generate/templates/server.go.tmpl
+++ b/generate/templates/server.go.tmpl
@@ -42,6 +42,7 @@ func {{ $serviceFunc }}(handler {{ $serviceType }}, middleware ...services.Middl
 		Handler: handler,
 		Endpoints: []services.Endpoint{
 		{{ range .Service.Functions }}
+			{{ $fn := . }}
 			{
 				ServiceName: "{{ $serviceName }}",
 				Name:        "{{ .Name }}",
@@ -71,6 +72,13 @@ func {{ $serviceFunc }}(handler {{ $serviceType }}, middleware ...services.Middl
 						},
 						Group:       "{{ .Group }}",
 						Status:      {{ .Status }},
+						ServiceName: "{{ $serviceName }}",
+						Name:        "{{ $fn.Name }}",
+						Roles:  []string{
+						{{- range $fn.Roles }}
+							"{{ . }}",
+						{{- end }}
+						},
 					},
 				{{ end }}
 				},

--- a/services/endpoint.go
+++ b/services/endpoint.go
@@ -33,7 +33,7 @@ type Endpoint struct {
 	//        "group.{Group.ID}.write",
 	//    }
 	//
-	// Notices that the roles should be allowed to have path variables that we can fill in
+	// Notice that the roles should be allowed to have path variables that we can fill in
 	// at runtime with the incoming binding data.
 	Roles []string
 	// Routes defines the actual ingress routes that allow this service operation to
@@ -75,4 +75,12 @@ type EndpointRoute struct {
 	// Status is mainly used by API gateway routes to determine what HTTP status code we should
 	// return to the caller when this endpoint succeeds. By default, this is 200.
 	Status int
+	// Roles helps support role-based security by defining role patterns to indicate which
+	// users are allowed to access this endpoint. This is the same as the Roles in the parent Endpoint that
+	// this route belongs to.
+	Roles []string
+	// ServiceName is the name of the service that this operation is part of.
+	ServiceName string
+	// Name is the name of the function/operation that this endpoint describes.
+	Name string
 }

--- a/services/gateways/apis/gateway.go
+++ b/services/gateways/apis/gateway.go
@@ -69,7 +69,7 @@ func (gw *Gateway) Type() services.GatewayType {
 // web server code already does. The only difference is that when the gateway shuts
 // down gracefully, this will return nil instead of http.ErrServerClosed. All other
 // errors are propagated back.
-func (gw *Gateway) Listen() error {
+func (gw *Gateway) Listen(_ context.Context) error {
 	// The Go 1.22 ServeMux doesn't have a special hook for missing routes. You just need to add some "catch-all"
 	// routes that are used when none of your service functions' paths match. We do this here because at this point
 	// all "real" routes should be in place.

--- a/services/server.go
+++ b/services/server.go
@@ -54,7 +54,7 @@ type Gateway interface {
 	//     even when things shut down as expected. Gateway instances should keep their
 	//     whore mouths shut and only report an error when there's actually something
 	//     to be concerned about.
-	Listen() error
+	Listen(ctx context.Context) error
 	// Shutdown should attempt to gracefully wind down processing of requests. Where
 	// possible, you should use the context to determine if/when you should give up
 	// on dealing with existing work. Implementations should try to follow these rules:
@@ -251,7 +251,7 @@ func (server *Server) Run(ctx context.Context) error {
 	errs, _ := fail.NewGroup(ctx)
 	for _, gw := range server.gateways {
 		server.logger.Info("[frodo] starting gateway: " + gw.Type().String())
-		errs.Go(gw.Listen)
+		errs.Go(func() error { return gw.Listen(ctx) })
 	}
 
 	// We had an issue starting up the server, so just get out and

--- a/services/server.go
+++ b/services/server.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"os/signal"
+	"slices"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -128,6 +131,7 @@ func NewServer(options ...ServerOption) *Server {
 		onPanic: func(err error, stack []byte) {
 			fmt.Printf("Panic: %v\n%v\n", err, string(stack))
 		},
+		logger: slog.New(slog.NewJSONHandler(nopWriter{}, nil)),
 	}
 	for _, option := range options {
 		option(&instance)
@@ -152,6 +156,12 @@ func NewServer(options ...ServerOption) *Server {
 	return &instance
 }
 
+type nopWriter struct{}
+
+func (w nopWriter) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
 // Server is the primordial component that wrangles all of your services and gateways to get
 // them talking to each other. You should not create one of these yourself. Instead, you should
 // use the NewServer() constructor to do that for you.
@@ -170,6 +180,8 @@ type Server struct {
 	// onPanic is a customizable callback that lets you perform custom logging/logic whenever the server
 	// recovers from a panic that occurred during your function calls.
 	onPanic OnPanicFunc
+	// logger customizes how you want low-level frodo logging to be written.
+	logger *slog.Logger
 }
 
 func (server *Server) registerEndpoint(endpoint Endpoint) {
@@ -189,6 +201,28 @@ func (server *Server) registerEndpoint(endpoint Endpoint) {
 			gw.Register(endpoint, route)
 		}
 	}
+}
+
+func (server *Server) Routes(gatewayType GatewayType) []EndpointRoute {
+	var routes []EndpointRoute
+	for _, service := range server.services {
+		for _, endpoint := range service.Endpoints {
+			for _, route := range endpoint.Routes {
+				if route.GatewayType == gatewayType {
+					routes = append(routes, route)
+				}
+			}
+		}
+	}
+
+	slices.SortFunc(routes, func(a, b EndpointRoute) int {
+		pathComp := strings.Compare(a.Path, b.Path)
+		if pathComp == 0 {
+			return strings.Compare(a.Method, b.Method)
+		}
+		return pathComp
+	})
+	return routes
 }
 
 // Invoke allows you to manually trigger any registered service endpoint/function given the name
@@ -211,11 +245,12 @@ func (server *Server) Invoke(ctx context.Context, serviceName string, methodName
 // Run turns on every gateway currently assigned to this service runtime. Call this
 // once your service setup and registration is complete in order to start accepting
 // incoming requests through your gateway(s).
-func (server *Server) Run() error {
+func (server *Server) Run(ctx context.Context) error {
 	server.shutdownComplete.Add(1)
 
-	errs, _ := fail.NewGroup(context.Background())
+	errs, _ := fail.NewGroup(ctx)
 	for _, gw := range server.gateways {
+		server.logger.Info("[frodo] starting gateway: " + gw.Type().String())
 		errs.Go(gw.Listen)
 	}
 
@@ -270,7 +305,7 @@ func (server *Server) Shutdown(ctx context.Context) error {
 //	void main() {
 //		server := services.NewServer(...)
 //		go server.ShutdownOnInterrupt(10*time.Second)
-//		server.Run()
+//		server.Run(context.Background())
 //	}
 func (server *Server) ShutdownOnInterrupt(gracefulTimeout time.Duration) {
 	// Block while waiting for a SIGTERM or SIGINT signal from the shell.
@@ -322,5 +357,12 @@ type OnPanicFunc func(err error, stack []byte)
 func OnPanic(handler OnPanicFunc) ServerOption {
 	return func(server *Server) {
 		server.onPanic = handler
+	}
+}
+
+// WithLogger customizes the logger used by the server to output various bits of debugging info.
+func WithLogger(logger *slog.Logger) ServerOption {
+	return func(server *Server) {
+		server.logger = logger
 	}
 }

--- a/services/server_test.go
+++ b/services/server_test.go
@@ -60,7 +60,7 @@ func (suite *ServerSuite) start() (*services.Server, *testext.Sequence, func()) 
 			sequence.Append("OnPanic:" + err.Error())
 		}),
 	)
-	go func() { _ = server.Run() }()
+	go func() { _ = server.Run(context.Background()) }()
 
 	// Kinda crappy, but we need some time to make sure the server is up. Sometimes
 	// this goes so fast that the test case fires before the server is fully running.


### PR DESCRIPTION
This is a hodgepodge of fixes to make the NATS broker actually work. The original implementation was many versions of NATS ago, and they've since updated JetStream's API. It's much nicer, and now things actually work. Before, if you had 5 instances of a server running, they would join a consumer group together which was great... but if you turned one off, all 5 lost their subscriptions and NATS deleted the queue.

Now, the traditional groups are implemented as durable consumers and the "GROUP *" subscribers are handled using ephemeral consumers. The code sucks much less, too!